### PR TITLE
Add a new way of using this module by skipping slow tests by default.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,7 @@
+0.05    not released yet
+        - Add parameter to skip test by default
+        - Some more tests
+
 0.04    not released yet
 
 0.03    1/19/2010

--- a/lib/Test/Slow.pm
+++ b/lib/Test/Slow.pm
@@ -22,16 +22,39 @@ variable to a true value:
 
    $ QUICK_TEST=1 prove --lib t/*t
 
+
+The other approach is to disable slow tests by default and run 
+them only when requested :
+
+   use Test::Slow "skip";
+   use Test::More;
+   ...
+   done_testing;
+
+To run even the slow tests, set the C<SLOW_TESTS> environment 
+variable to a true value :
+
+   $ SLOW_TEST=1 prove --lib t/*t
+
+
 =cut
 
 use warnings;
 use strict;
 use Test::More;
 
-our $VERSION = '0.04';
+our $VERSION = '0.05';
 
 BEGIN {
-    plan(skip_all => 'Slow test.') if $ENV{QUICK_TEST};
+    sub import { 
+	    my ($package, $msg) = @_; 
+
+	    if(defined $msg and $msg eq "skip") { 
+		    plan(skip_all => 'Slow test.') unless $ENV{SLOW_TEST};
+	    } else {
+		    plan(skip_all => 'Slow test.') if $ENV{QUICK_TEST};
+	    }
+    }
 }
 
 =head1 COPYRIGHT & LICENSE

--- a/t/01-skip.t
+++ b/t/01-skip.t
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Slow "skip";
+
+# I want to skip this test
+die();
+
+done_testing;

--- a/t/02-skipforced.t
+++ b/t/02-skipforced.t
@@ -1,0 +1,14 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+BEGIN {
+	$ENV{SLOW_TEST} = 1;
+}
+use Test::Slow;
+
+# I want to execute this test thanks to env var SLOW_TEST=1
+ok(1);
+
+done_testing;

--- a/t/03-quick.t
+++ b/t/03-quick.t
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+use Test::Slow;
+
+# I want to execute this test as I do not asked to do quick tests
+ok(1);
+
+done_testing;

--- a/t/04-quickforced.t
+++ b/t/04-quickforced.t
@@ -1,0 +1,14 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+use Test::More;
+BEGIN {
+	$ENV{QUICK_TEST} = 1;
+}
+use Test::Slow;
+
+# I want to skip this test, I set and env var for this
+die()
+
+done_testing;


### PR DESCRIPTION
Hello @zoul !

First thank you for this cool module :)

I wanted to use it but prefer to skip slow tests by default so instead of changing the default design I propose to add a new parameter when importing so we keep the old behaviour and add a new way of using your module.

I added also some tests and updated the doc.

Please review and merge if you consider it good for you :smiley: 

Best regards.

Thibault